### PR TITLE
Fixing NPE in S3ConfigController.scala and a typo in input.jsp

### DIFF
--- a/s3-plugin-server/src/main/resources/buildServerResources/input.jsp
+++ b/s3-plugin-server/src/main/resources/buildServerResources/input.jsp
@@ -13,7 +13,7 @@
                 <td>
                     <label for="access-key">AWS Access Key</label>
                 </td><td>
-                    <input type="text" id="access-key" name="${accessKey}" value="" class="longField">
+                    <input type="text" id="access-key" name="accessKey" value="${accessKey}" class="longField">
                     <div class="grayNote">
                         If either the AWS Access Key or AWS Secret Key are not specified, teamcity will fall back to using the
                         <a href="http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html">

--- a/s3-plugin-server/src/main/scala/com/gu/teamcity/S3ConfigController.scala
+++ b/s3-plugin-server/src/main/scala/com/gu/teamcity/S3ConfigController.scala
@@ -19,5 +19,5 @@ class S3ConfigController(extension: S3ConfigManager, webControllerManager: WebCo
     new ModelAndView(new RedirectView("/admin/admin.html?item=S3"))
   }
 
-  def emptyAsNone(s: String): Option[String] = if (s.trim.isEmpty) None else Some(s)
+  def emptyAsNone(s: String): Option[String] = if (s == null || s.trim.isEmpty) None else Some(s)
 }


### PR DESCRIPTION
Hi,

I tried the plugin with TeamCity 9.0.3 and it was throwing an NPE when submitting AWS credentials so this PR fixes this.
