### PR TITLE
convert TC input stream to a file for S3 uploads

### DIFF
--- a/s3-plugin-server/src/main/scala/com/gu/teamcity/S3.scala
+++ b/s3-plugin-server/src/main/scala/com/gu/teamcity/S3.scala
@@ -49,7 +49,7 @@ class S3(config: S3ConfigManager) {
 object MakeFile {
 
   def apply(input: InputStream): File = {
-    val file = File.createTempFile("artefact", "")
+    val file = File.createTempFile("s3-plugin", "")
     val output = new FileOutputStream(file)
     try {
       val bytes = new Array[Byte](1024)

--- a/s3-plugin-server/src/main/scala/com/gu/teamcity/S3.scala
+++ b/s3-plugin-server/src/main/scala/com/gu/teamcity/S3.scala
@@ -1,17 +1,14 @@
 package com.gu.teamcity
 
-import java.io.InputStream
+import java.io.{File, FileOutputStream, InputStream}
 
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.{AWSCredentialsProviderChain, DefaultAWSCredentialsProviderChain}
-import com.amazonaws.event.{ProgressEvent, ProgressListener}
 import com.amazonaws.services.s3.AmazonS3Client
-import com.amazonaws.services.s3.model.{PutObjectRequest, ObjectMetadata}
-import com.amazonaws.services.s3.transfer.{PersistableTransfer, TransferManager}
-import com.amazonaws.services.s3.transfer.internal.{S3ProgressListenerChain, TransferManagerUtils, S3ProgressListener}
+import com.amazonaws.services.s3.model.PutObjectRequest
+import com.amazonaws.services.s3.transfer.TransferManager
 import jetbrains.buildServer.serverSide.SBuild
 
-import scala.concurrent.Promise
 import scala.util.{Success, Try}
 
 class S3(config: S3ConfigManager) {
@@ -29,15 +26,41 @@ class S3(config: S3ConfigManager) {
     (for (bucket <- targetBucket) yield
       Try {
         val uploadDirectory = s"${S3Plugin.cleanFullName(build)}/${build.getBuildNumber}"
-        val metadata = {
-          val md = new ObjectMetadata()
-          md.setContentLength(fileSize)
-          md
-        }
-        val req = new PutObjectRequest(bucket, s"$uploadDirectory/$fileName", contents, metadata)
+        val req: PutObjectRequest = putRequestAsFile(bucket, s"$uploadDirectory/$fileName", contents)
         val upload = transferManager.upload(req)
         upload.waitForUploadResult()
         true
       }
-    ) getOrElse (Success(false))
+    ) getOrElse Success(false)
+
+  def putRequestAsFile(bucket: String, targetName: String, contents: InputStream): PutObjectRequest = {
+    // convert to a file, then the S3 client can do parallel upload, and also not fail with reset stream problems
+    val file = MakeFile(contents)
+    val req = new PutObjectRequest(bucket, targetName, file)
+    contents.close()
+    req
+  }
+
+}
+
+/**
+ * Return the input stream as a File, consuming everything but not closing it.
+ */
+object MakeFile {
+
+  def apply(input: InputStream): File = {
+    val file = File.createTempFile("artefact", "")
+    val output = new FileOutputStream(file)
+    try {
+      val bytes = new Array[Byte](1024)
+      Iterator
+        .continually(input.read(bytes))
+        .takeWhile(-1 != _)
+        .foreach(read => output.write(bytes, 0, read))
+    } finally {
+      output.close()
+    }
+    file
+  }
+
 }

--- a/s3-plugin-server/src/test/scala/com/gu/teamcity/MakeFileSpec.scala
+++ b/s3-plugin-server/src/test/scala/com/gu/teamcity/MakeFileSpec.scala
@@ -1,0 +1,17 @@
+package com.gu.teamcity
+
+import java.io.ByteArrayInputStream
+import java.nio.file.{Files, Paths}
+
+import org.scalatest._
+
+class MakeFileSpec extends FlatSpec with Matchers {
+
+  "file maker" should "turn an input stream into a file" in {
+    val testData = Array.fill(scala.util.Random.nextInt(4096))((scala.util.Random.nextInt(256) - 128).toByte)
+    val stream = new ByteArrayInputStream(testData)
+    val result = MakeFile(stream)
+    Files.readAllBytes(Paths.get(result.toURI)) should be(testData)
+  }
+
+}


### PR DESCRIPTION
Uploading as an InputStream causes loads of errors because it can't reset the stream every time it needs to.  Also, it can only do parallel uploads for files.

Therefore this changes it to write the TC InputStream to a temp file and then use that to upload.

I don't delete it afterwards, but it should put it in /tmp.  Maybe it's something we need to think about cleaning up though?

@philwills 
