### PR TITLE
Update aws-java-sdk-s3 and joda-time for Java8 Compat

### DIFF
--- a/s3-plugin-server/pom.xml
+++ b/s3-plugin-server/pom.xml
@@ -13,13 +13,13 @@
       <dependency>
           <groupId>com.amazonaws</groupId>
           <artifactId>aws-java-sdk-s3</artifactId>
-          <version>1.9.23</version>
+          <version>1.11.23</version>
       </dependency>
 
       <dependency>
           <groupId>joda-time</groupId>
           <artifactId>joda-time</artifactId>
-          <version>2.8.2</version>
+          <version>2.9.4</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
joda-time and the aws s3 sdk need to be updated to allow uploads to work when running under java8
