### PR TITLE
Added feature to set path to artifacts in S3, fix for #20, and changes to handling of hidden artifacts

### DIFF
--- a/s3-plugin-server/src/main/resources/buildServerResources/input.jsp
+++ b/s3-plugin-server/src/main/resources/buildServerResources/input.jsp
@@ -51,6 +51,12 @@
                 </td><td>
                     <input type="password" id="secret-key" name="secretKey" class="longField">
                 </td>
+            </tr><tr>
+                <td>
+                    <label for="folderPath">Folder path (supports parameters)</label>
+                </td><td>
+                    <input type="text" id="folderPath" name="folderPath" value="${folderPath}" class="longField">
+                </td>
             </tr>
         </tbody>
     </table>

--- a/s3-plugin-server/src/main/scala/com/gu/teamcity/ArtifactUploader.scala
+++ b/s3-plugin-server/src/main/scala/com/gu/teamcity/ArtifactUploader.scala
@@ -50,7 +50,9 @@ object ArtifactUploader {
   def getChildren(file: File, paths: Seq[String] = Nil, current: String = ""): Seq[(String, File)] = {
     file.listFiles.toSeq.flatMap {
       child =>
-        if (child.isHidden) {
+        // TeamCity only considers the .teamcity folder to be hidden artifacts
+        // See https://confluence.jetbrains.com/display/TCD10/Build+Artifact
+        if (child.getName == ".teamcity") {
           Seq()
         } else {
           val newPath = current + child.getName

--- a/s3-plugin-server/src/main/scala/com/gu/teamcity/ArtifactUploader.scala
+++ b/s3-plugin-server/src/main/scala/com/gu/teamcity/ArtifactUploader.scala
@@ -55,7 +55,7 @@ object ArtifactUploader {
         } else {
           val newPath = current + child.getName
           if (child.isDirectory) {
-            getChildren(child, paths, newPath + File.separator)
+            getChildren(child, paths, newPath + '/')
           } else {
             Seq((newPath, child))
           }

--- a/s3-plugin-server/src/main/scala/com/gu/teamcity/S3.scala
+++ b/s3-plugin-server/src/main/scala/com/gu/teamcity/S3.scala
@@ -24,7 +24,7 @@ class S3(config: S3ConfigManager) {
 
   def upload(bucket: String, build: SBuild, fileName: String, contents: InputStream, fileSize: Long): Try[Unit] =
     Try {
-      val uploadDirectory = s"${S3Plugin.cleanFullName(build)}/${build.getBuildNumber}"
+      val uploadDirectory = s"${S3Plugin.fillParameters(build, config.folderPath.get)}"
       val metadata = {
         val md = new ObjectMetadata()
         md.setContentLength(fileSize)
@@ -38,7 +38,7 @@ class S3(config: S3ConfigManager) {
 
   def upload(bucket: String, build: SBuild, fileName: String, file: File): Try[Unit] =
     Try {
-      val uploadDirectory = s"${S3Plugin.cleanFullName(build)}/${build.getBuildNumber}"
+      val uploadDirectory = s"${S3Plugin.fillParameters(build, config.folderPath.get)}"
       val req = new PutObjectRequest(bucket, s"$uploadDirectory/$fileName", file)
       req.withCannedAcl(CannedAccessControlList.BucketOwnerFullControl)
       val upload = transferManager.upload(req)

--- a/s3-plugin-server/src/main/scala/com/gu/teamcity/S3ConfigController.scala
+++ b/s3-plugin-server/src/main/scala/com/gu/teamcity/S3ConfigController.scala
@@ -16,7 +16,7 @@ class S3ConfigController(config: S3ConfigManager, webControllerManager: WebContr
 
     config.updateAndPersist(S3Config(
       param("artifactBucket"), param("buildManifestBucket"), param("tagManifestBucket"),
-      param("accessKey"), param("secretKey")
+      param("accessKey"), param("secretKey"), param("folderPath")
     ))
 
     new ModelAndView(new RedirectView("/admin/admin.html?item=S3"))

--- a/s3-plugin-server/src/main/scala/com/gu/teamcity/S3ConfigManager.scala
+++ b/s3-plugin-server/src/main/scala/com/gu/teamcity/S3ConfigManager.scala
@@ -11,7 +11,8 @@ import org.json4s.native.Serialization._
 
 case class S3Config(
   artifactBucket: Option[String], buildManifestBucket: Option[String], tagManifestBucket: Option[String],
-  awsAccessKey: Option[String], awsSecretKey: Option[String]
+  awsAccessKey: Option[String], awsSecretKey: Option[String],
+  folderPath: Option[String] = Some("%system.teamcity.projectName%::%system.teamcity.buildConfName%/%build.number%")
 )
 
 class S3ConfigManager(paths: ServerPaths) extends AWSCredentialsProvider {
@@ -28,6 +29,7 @@ class S3ConfigManager(paths: ServerPaths) extends AWSCredentialsProvider {
   def artifactBucket: Option[String] = config.flatMap(_.artifactBucket)
   def buildManifestBucket: Option[String] = config.flatMap(_.buildManifestBucket)
   def tagManifestBucket: Option[String] = config.flatMap(_.tagManifestBucket)
+  def folderPath: Option[String] = config.flatMap(_.folderPath)
 
   private[teamcity] def update(config: S3Config): Unit = {
     this.config = Some(if (config.awsSecretKey.isEmpty && config.awsAccessKey == this.config.flatMap(_.awsAccessKey)) {
@@ -48,7 +50,8 @@ class S3ConfigManager(paths: ServerPaths) extends AWSCredentialsProvider {
     "artifactBucket" -> artifactBucket,
     "buildManifestBucket" -> buildManifestBucket,
     "tagManifestBucket" -> tagManifestBucket,
-    "accessKey" -> config.flatMap(_.awsAccessKey)
+    "accessKey" -> config.flatMap(_.awsAccessKey),
+    "folderPath" -> folderPath
   )
 
   override def getCredentials: AWSCredentials = (for {

--- a/s3-plugin-server/src/main/scala/com/gu/teamcity/S3Plugin.scala
+++ b/s3-plugin-server/src/main/scala/com/gu/teamcity/S3Plugin.scala
@@ -11,4 +11,5 @@ class S3Plugin(eventDispatcher: EventDispatcher[BuildServerListener], s3: S3, s3
 
 object S3Plugin {
   def cleanFullName(build: SBuild): String = build.getFullName.split(" :: ").mkString("::")
+  def fillParameters(build: SBuild, input: String) : String = build.getValueResolver.resolve(input).getResult
 }

--- a/s3-plugin-server/src/test/scala/com/gu/teamcity/S3ConfigManagerSpec.scala
+++ b/s3-plugin-server/src/test/scala/com/gu/teamcity/S3ConfigManagerSpec.scala
@@ -7,7 +7,7 @@ class S3ConfigManagerSpec extends FlatSpec with Matchers {
   "secret" should "be persisted" in {
     val configManager = new S3ConfigManager(new ServerPaths("", "", "", ""))
 
-    configManager.update(S3Config(None, None, None, Some("key"), Some("secret")))
+    configManager.update(S3Config(None, None, None, Some("key"), Some("secret"), None))
 
     configManager.config.flatMap(_.awsSecretKey) should be (Some("secret"))
   }
@@ -15,8 +15,8 @@ class S3ConfigManagerSpec extends FlatSpec with Matchers {
   "secret" should "stay same if key same and secret empty" in {
     val configManager = new S3ConfigManager(new ServerPaths("", "", "", ""))
 
-    configManager.update(S3Config(None, None, None, Some("key"), Some("secret")))
-    configManager.update(S3Config(None, None, None, Some("key"), None))
+    configManager.update(S3Config(None, None, None, Some("key"), Some("secret"), None))
+    configManager.update(S3Config(None, None, None, Some("key"), None, None))
 
     configManager.config.flatMap(_.awsSecretKey) should be (Some("secret"))
   }
@@ -24,8 +24,8 @@ class S3ConfigManagerSpec extends FlatSpec with Matchers {
   "secret" should "stay reset if key changes and secret empty" in {
     val configManager = new S3ConfigManager(new ServerPaths("", "", "", ""))
 
-    configManager.update(S3Config(None, None, None, Some("key"), Some("secret")))
-    configManager.update(S3Config(None, None, None, Some("new key"), None))
+    configManager.update(S3Config(None, None, None, Some("key"), Some("secret"), None))
+    configManager.update(S3Config(None, None, None, Some("new key"), None, None))
 
     configManager.config.flatMap(_.awsSecretKey) should be (None)
   }


### PR DESCRIPTION
I made some changes to this plugin in order to make it work better for my organization:

1. I added a feature to set the path to the artifacts in S3. This supports parameters in TeamCity. It defaults to the equivalent of the existing hardcoded path.
2. I implemented the fix described in #20, which seems to also work fine on Linux. This means that folder paths won't be mangled when a Windows TeamCity server is used.
3. I changed the code so that only the ".teamcity" folder is excluded from being pushed to S3. This mirrors how only that specific folder is considered "hidden artifacts" by TeamCity. It would probably be a good idea to also add a checkbox to enable/disable pushing this folder, but we don't personally need it.