### PR TITLE
Support teamcity 2018.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ You need to install a version matching your TeamCity version:
 
 |   TeamCity    |  S3 Plugin |
 |---------------|------------|
+|   2018.x      |   1.7.0    |
 |   10.0.x      |   1.6.0    |
 |   9.1.x       |   1.5.0    |
 |   8.1x        |   1.4.0    |
+
 
 Build
 -----

--- a/pom.xml
+++ b/pom.xml
@@ -3,10 +3,10 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.gu.teamcity</groupId>
   <artifactId>s3-plugin</artifactId>
-  <version>1.5.2-SNAPSHOT</version>
+  <version>1.7.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <properties>
-      <teamcity-version>10.0.2</teamcity-version>
+      <teamcity-version>2018.1</teamcity-version>
   </properties>
   <repositories>
     <repository>

--- a/s3-plugin-server/src/main/scala/com/gu/teamcity/S3Plugin.scala
+++ b/s3-plugin-server/src/main/scala/com/gu/teamcity/S3Plugin.scala
@@ -10,5 +10,5 @@ class S3Plugin(eventDispatcher: EventDispatcher[BuildServerListener], s3: S3, s3
 }
 
 object S3Plugin {
-  def cleanFullName(build: SBuild): String = build.getFullName.split(" :: ").mkString("::")
+  def cleanFullName(build: SBuild): String = build.getFullName.split(" / ").mkString("::")
 }


### PR DESCRIPTION
In version 2018.1, teamcity decided to change the subproject separator from :: to / - see https://confluence.jetbrains.com/display/TCD18/Upgrade+Notes for release notes detailing this. 

To deal with this (and prevent all future builds getting a different s3 key) this change updates the cleanFullName function to deal with the new separator.